### PR TITLE
Change defaults to `true` for hide-ignored-files settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,13 +66,13 @@
     },
     "hideVcsIgnoredFiles": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "title": "Hide VCS Ignored Files",
       "description": "Don't show files and directories ignored by the current project's VCS system. For example, projects using Git have these paths defined in their `.gitignore` file."
     },
     "hideIgnoredNames": {
       "type": "boolean",
-      "default": false,
+      "default": true,
       "description": "Don't show items matched by the `Ignored Names` core config setting."
     },
     "sortFoldersBeforeFiles": {


### PR DESCRIPTION

### Description of the Change

[It was argued](https://github.com/pulsar-edit/pulsar/issues/195) by @SpaceToastKADK and @mjrodgers — convincingly, in my opinion — that the “Hide Ignored Files” option in `tree-view` should be enabled by default. The Core settings explain that the ignored files list applies to packages like fuzzy-finder and tree-view, and does not qualify that statement by mentioning that you need to go into tree-view's settings to enable that behavior. I'd argue that this should also apply to the “Hide VCS ignored files” setting as well. 

### Alternate Designs

A more drastic solution would be to do away with this setting entirely. But I think it's good that we have a setting for this, because there's an argument for tree-view needing to show the actual state of the directory in a way that fuzzy-finder and find-and-replace do not.

### Benefits

New users won't get quite as confused.

### Possible Drawbacks

This might illustrate another problem we have regarding discoverability of package settings. I think users are trained to hunt for a package's settings page more easily when it's an external package that they've searched for and downloaded. I think it's not quite as intuitive when you need to change the settings of a _built-in_ package.

To change the way the tree view behaves, you have to recognize that it's a self-contained package whose name is `tree-view`. Even then, the settings page is several clicks away. I think that's a long-term problem without an obvious fix, but I'm sure there'll be a lively debate.

### Applicable Issues

Reported in [pulsar#195](https://github.com/pulsar-edit/pulsar/issues/195).
